### PR TITLE
 Fix Most traveled destination API URL

### DIFF
--- a/spec/amadeus/namespaces.test.js
+++ b/spec/amadeus/namespaces.test.js
@@ -25,7 +25,7 @@ describe('Namespaces', () => {
 
       expect(amadeus.travel).toBeDefined();
       expect(amadeus.travel.analytics).toBeDefined();
-      expect(amadeus.travel.analytics.airTraffics).toBeDefined();
+      expect(amadeus.travel.analytics.airTraffic).toBeDefined();
       expect(amadeus.travel.analytics.fareSearches).toBeDefined();
 
       expect(amadeus.shopping).toBeDefined();
@@ -45,7 +45,7 @@ describe('Namespaces', () => {
       expect(amadeus.referenceData.locations.get).toBeDefined();
       expect(amadeus.referenceData.locations.airports.get).toBeDefined();
 
-      expect(amadeus.travel.analytics.airTraffics.get).toBeDefined();
+      expect(amadeus.travel.analytics.airTraffic.get).toBeDefined();
       expect(amadeus.travel.analytics.fareSearches.get).toBeDefined();
 
       expect(amadeus.shopping.flightDates.get).toBeDefined();
@@ -85,11 +85,11 @@ describe('Namespaces', () => {
         .toHaveBeenCalledWith('/v1/reference-data/locations/airports', {});
     });
 
-    it('.amadeus.travel.analytics.airTraffics.get', () => {
+    it('.amadeus.travel.analytics.airTraffic.get', () => {
       amadeus.client.get = jest.fn();
-      amadeus.travel.analytics.airTraffics.get();
+      amadeus.travel.analytics.airTraffic.get();
       expect(amadeus.client.get)
-        .toHaveBeenCalledWith('/v1/travel/analytics/air-traffics', {});
+        .toHaveBeenCalledWith('/v1/travel/analytics/air-traffic/traveled', {});
     });
 
     it('.amadeus.travel.analytics.fareSearches.get', () => {

--- a/src/amadeus/namespaces/travel/analytics.js
+++ b/src/amadeus/namespaces/travel/analytics.js
@@ -1,4 +1,4 @@
-import AirTraffics  from './analytics/air_traffics';
+import AirTraffic  from './analytics/air_traffic';
 import FareSearches from './analytics/fare_searches';
 
 /**
@@ -19,7 +19,7 @@ import FareSearches from './analytics/fare_searches';
 class Analytics {
   constructor(client) {
     this.client        = client;
-    this.airTraffics  = new AirTraffics(client);
+    this.airTraffic   = new AirTraffic(client);
     this.fareSearches = new FareSearches(client);
   }
 }

--- a/src/amadeus/namespaces/travel/analytics/air_traffic.js
+++ b/src/amadeus/namespaces/travel/analytics/air_traffic.js
@@ -1,17 +1,17 @@
 /**
  * A namespaced client for the
- * `/v1/travel/analytics/air-traffics` endpoints
+ * `/v1/travel/analytics/air-traffic/traveled` endpoints
  *
  * Access via the {@link Amadeus} object
  *
  * ```js
  * let amadeus = new Amadeus();
- * amadeus.travel.analytics.airTraffics;
+ * amadeus.travel.analytics.airTraffic;
  * ```
  *
  * @param {Client} client
  */
-class AirTraffics {
+class AirTraffic {
   constructor(client) {
     this.client = client;
   }
@@ -29,15 +29,15 @@ class AirTraffics {
    * Find the air traffic from LHR in January 2011
    *
    * ```js
-   * amadeus.travel.analytics.airTraffics.get({
+   * amadeus.travel.analytics.airTraffic.get({
    *   origin: 'LHR',
    *   period: '2011-01'
    * });
    * ```
    */
   get(params = {}) {
-    return this.client.get('/v1/travel/analytics/air-traffics', params);
+    return this.client.get('/v1/travel/analytics/air-traffic/traveled', params);
   }
 }
 
-export default AirTraffics;
+export default AirTraffic;


### PR DESCRIPTION
Fixes most traveled destination API

- Replace traffics for traffic on filenames, namespace and class name.
- Add 'traveled' to the URL.

