### PR TITLE
Adding support for Hotel Ratings API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.2.0 - 2019-07-31
+
+## Hotel Ratings API
+
+New version of the Node SDK to support a new endpoint:
+
+* [Hotel Ratings](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-ratings/api-reference)
+
+
 ## 3.1.0 - 2019-04-08
 
 ## Points of interest API

--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ amadeus.referenceData.locations.pointsOfInterest.bySquare.get({
     south: 41.394582,
     east: 2.177181
 })
+
+// Hotel Ratings
+// Get Sentiment Analysis of reviews about Holiday Inn Paris Notre Dame.
+amadeus.eReputation.hotelSentiments.get({
+    hotelIds: 'XKPARC12'
+})
 ```
 
 ## Development & Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amadeus",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Node library for the Amadeus travel APIs",
   "main": "lib/amadeus.js",
   "scripts": {
@@ -45,7 +45,8 @@
   "contributors": [
     "cbetta",
     "Anthony Roux",
-    "Alvaro Navarro"
+    "Alvaro Navarro",
+    "Akshit Singla"
   ],
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/spec/amadeus/namespaces.test.js
+++ b/spec/amadeus/namespaces.test.js
@@ -44,6 +44,9 @@ describe('Namespaces', () => {
       expect(amadeus.shopping.hotelOffers).toBeDefined();
       expect(amadeus.shopping.hotelOffersByHotel).toBeDefined();
       expect(amadeus.shopping.hotelOffer).toBeDefined();
+
+      expect(amadeus.eReputation).toBeDefined();
+      expect(amadeus.eReputation.hotelSentiments).toBeDefined();
     });
 
     it('should define all expected .get methods', () => {
@@ -68,6 +71,8 @@ describe('Namespaces', () => {
       expect(amadeus.shopping.hotelOffers.get).toBeDefined();
       expect(amadeus.shopping.hotelOffersByHotel.get).toBeDefined();
       expect(amadeus.shopping.hotelOffer('XXX').get).toBeDefined();
+
+      expect(amadeus.eReputation.hotelSentiments.get).toBeDefined();
     });
 
     it('.amadeus.referenceData.urls.checkinLinks.get', () => {
@@ -194,6 +199,13 @@ describe('Namespaces', () => {
       amadeus.shopping.hotelOffer('XXX').get();
       expect(amadeus.client.get)
         .toHaveBeenCalledWith('/v2/shopping/hotel-offers/XXX', {});
+    });
+
+    it('.amadeus.eReputation.hotelSentiments.get', () => {
+      amadeus.client.get = jest.fn();
+      amadeus.eReputation.hotelSentiments.get();
+      expect(amadeus.client.get)
+        .toHaveBeenCalledWith('/v2/e-reputation/hotel-sentiments', {});
     });
   });
 });

--- a/src/amadeus.js
+++ b/src/amadeus.js
@@ -4,6 +4,7 @@ import Pagination    from './amadeus/client/pagination';
 import ReferenceData from './amadeus/namespaces/reference_data';
 import Shopping      from './amadeus/namespaces/shopping';
 import Travel        from './amadeus/namespaces/travel';
+import EReputation   from './amadeus/namespaces/e_reputation';
 
 /**
  * The Amadeus client library for accessing the travel APIs.
@@ -58,6 +59,7 @@ class Amadeus {
     this.referenceData  = new ReferenceData(this.client);
     this.shopping       = new Shopping(this.client);
     this.travel         = new Travel(this.client);
+    this.eReputation    = new EReputation(this.client);
     this.pagination = new Pagination(this.client);
   }
 

--- a/src/amadeus/client/access_token.js
+++ b/src/amadeus/client/access_token.js
@@ -107,7 +107,7 @@ class AccessToken {
    */
   storeAccessToken(response) {
     this.accessToken = response.result['access_token'];
-    this.expiresAt = Date.now() + response.result['expires_in'];
+    this.expiresAt = Date.now() + (response.result['expires_in'] * 1000);
   }
 }
 

--- a/src/amadeus/namespaces/e_reputation.js
+++ b/src/amadeus/namespaces/e_reputation.js
@@ -1,0 +1,24 @@
+import HotelSentiments    from './e_reputation/hotel_sentiments';
+
+/**
+ * A namespaced client for the
+ * `/v1/e-reputation` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.eReputation;
+ * ```
+ *
+ * @param {Client} client
+ * @property {hotelSentiments} hotel_sentiments
+ */
+class EReputation {
+  constructor(client) {
+    this.client             = client;
+    this.hotelSentiments = new HotelSentiments(client);
+  }
+}
+
+export default EReputation;

--- a/src/amadeus/namespaces/e_reputation/hotel_sentiments.js
+++ b/src/amadeus/namespaces/e_reputation/hotel_sentiments.js
@@ -1,0 +1,40 @@
+/**
+ * A namespaced client for the
+ * `/v2/e-reputation/hotel-sentiments` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.eReputation.hotelSentiments;
+ * ```
+ *
+ * @param {Client} client
+ */
+class HotelSentiments {
+  constructor(client) {
+    this.client = client;
+  }
+
+  /**
+   * Get the sentiment analysis of hotel reviews
+   *
+   * @param {Object} params
+   * @param {string} params.hotelIds Comma separated list of Amadeus hotel
+   *   codes to request. Example: XKPARC12
+   * @return {Promise.<Response,ResponseError>} a Promise
+   *
+   * Get Sentiment Analysis of reviews about Holiday Inn Paris Notre Dame.
+   *
+   * ```js
+   * amadeus.eReputation.hotelSentiments.get({
+   *   hotelIds: 'XKPARC12'
+   * })
+   * ```
+   */
+  get(params = {}) {
+    return this.client.get('/v2/e-reputation/hotel-sentiments', params);
+  }
+}
+
+export default HotelSentiments;


### PR DESCRIPTION
## Changes for this pull request
New version of the Node SDK to support a new endpoint:
* [Hotel Ratings](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-ratings/api-reference)

