### PR TITLE
Capture ama-client-ref from header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amadeus",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Node library for the Amadeus travel APIs",
   "main": "lib/amadeus.js",
   "scripts": {
@@ -24,9 +24,12 @@
     "verbose": true,
     "testEnvironment": "node"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/amadeus4dev/amadeus-node.git"
+    "url": "git+https://github.com/Vyootrip-Dev/amadeus-node.git"
   },
   "keywords": [
     "amadeus",

--- a/spec/amadeus/client/response.test.js
+++ b/spec/amadeus/client/response.test.js
@@ -21,6 +21,7 @@ describe('Response', () => {
 
     it('should initialize the params', () => {
       expect(response.contentType).toBe('application/json');
+      expect(response.amaClientRef).toBeDefined();
       expect(response.statusCode).toBe(200);
       expect(response.request).toEqual(request);
       expect(response.body).toEqual('');

--- a/src/amadeus/client/response.js
+++ b/src/amadeus/client/response.js
@@ -19,6 +19,7 @@ class Response {
   constructor(http_response, request) {
     let headers = http_response.headers || {};
     this.contentType = headers['content-type'];
+    this.amaClientRef = headers['ama-client-ref'] || 'none';
     this.statusCode  = http_response.statusCode;
     this.request     = request;
     this.body        = '';


### PR DESCRIPTION
## Changes for this pull request

Capture ama-client-ref header attribute and put on request.amaClientHeader.
It is necesary to pass certification process and log to inform Amadeus of any issues.

## Checklist
* Add any changes to the README
* Add any changes or new comments to SDK methods
