### PR TITLE
Capture ama-request-id from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 5.0.0 - 2020-05-21
 Decommission Flight Low-Fare Search API
 
-Decomission Flight Choice Prediction v1
+Decommission Flight Choice Prediction v1
 
 Adding [Flight Choice Prediction v2](https://developers.amadeus.com/self-service/category/air/api-doc/flight-choice-prediction/api-reference)
 > The input of Flight Choice Prediction v2 is the result of Flight Offers Search API - in v1 the input was the result of Flight Low-Fare Search

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/5accb4b8a41e4e3fd1da/maintainability)](https://codeclimate.com/github/amadeus4dev/amadeus-node/maintainability)
 [![Dependencies](.github/images/dependencies.svg)](npmjs)
 [![Contact Support](https://img.shields.io/badge/contact-support-blue.svg)][support]
+[![Discord](https://img.shields.io/discord/696822960023011329?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/cVrFBqx)
 
 Amadeus provides a rich set of APIs for the travel industry. For more details, check out the [Amadeus for Developers Portal](https://developers.amadeus.com) or the [SDK class reference](https://amadeus4dev.github.io/amadeus-node/).
 

--- a/spec/amadeus/client/response.test.js
+++ b/spec/amadeus/client/response.test.js
@@ -22,6 +22,7 @@ describe('Response', () => {
     it('should initialize the params', () => {
       expect(response.contentType).toBe('application/json');
       expect(response.statusCode).toBe(200);
+      expect(response.amaRequestId).toBeDefined();
       expect(response.request).toEqual(request);
       expect(response.body).toEqual('');
       expect(response.result).toEqual(null);

--- a/src/amadeus/client/response.js
+++ b/src/amadeus/client/response.js
@@ -19,6 +19,7 @@ class Response {
   constructor(http_response, request) {
     let headers = http_response.headers || {};
     this.contentType = headers['content-type'];
+    this.amaRequestId = headers['ama-request-id'] || 'none';
     this.statusCode  = http_response.statusCode;
     this.request     = request;
     this.body        = '';


### PR DESCRIPTION
Fixes #

## Changes for this pull request

Capture ama-client-ref header attribute and put on request.amaClientHeader.
It is necesary to pass certification process and log to inform Amadeus of any issues.

## Checklist

Remove this if you have done all of these:

* Add any changes to the README
* Add any changes or new comments to SDK methods
