### PR TITLE
Update flight create orders and dates in dates in list of endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,21 +230,13 @@ amadeus.booking.flightOrders.post(
     console.log(responseError);
 });
 
-// Flight Choice Prediction
-amadeus.shopping.flightOffersSearch.get({
-    originLocationCode: 'SYD',
-    destinationLocationCode: 'BKK',
-    departureDate: '2021-04-01',
-    adults: '2'
-}).then(function(response){
-    return amadeus.shopping.flightOffers.prediction.post(
-      JSON.stringify(response)
-    );
-}).then(function(response){
-    console.log(response.data);
-}).catch(function(responseError){
-    console.log(responseError);
-});
+// Retrieve flight order with ID 'XXX'. This ID comes from the
+// Flight Create Orders API, which is a temporary ID in test environment.
+amadeus.booking.flightOrder('XXX').get()
+
+// Cancel flight order with ID 'XXX'. This ID comes from the
+// Flight Create Orders API, which is a temporary ID in test environment.
+amadeus.booking.flightOrder('XXX').delete()
 
 // Flight SeatMap Display
 // To retrieve the seat map of each flight included
@@ -268,6 +260,22 @@ amadeus.shopping.flightOffersSearch.get({
 // To retrieve the seat map for flight order with ID 'XXX'
 amadeus.shopping.seatmaps.get({
   'flight-orderId': 'XXX'
+});
+
+// Flight Choice Prediction
+amadeus.shopping.flightOffersSearch.get({
+    originLocationCode: 'SYD',
+    destinationLocationCode: 'BKK',
+    departureDate: '2021-04-01',
+    adults: '2'
+}).then(function(response){
+    return amadeus.shopping.flightOffers.prediction.post(
+      JSON.stringify(response)
+    );
+}).then(function(response){
+    console.log(response.data);
+}).catch(function(responseError){
+    console.log(responseError);
 });
 
 // Flight Checkin Links
@@ -339,14 +347,6 @@ amadeus.shopping.hotelOffersByHotel.get({
 })
 // Confirm the availability of a specific offer id
 amadeus.shopping.hotelOffer('XXX').get()
-
-// Retrieve flight order with ID 'XXX'. This ID comes from the
-// Flight Create Orders API, which is a temporary ID in test environment.
-amadeus.booking.flightOrder('XXX').get()
-
-// Cancel flight order with ID 'XXX'. This ID comes from the
-// Flight Create Orders API, which is a temporary ID in test environment.
-amadeus.booking.flightOrder('XXX').delete()
 
 // Hotel Booking API
 amadeus.booking.hotelBookings.post(

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ amadeus.shopping.flightOffersSearch.get({
 });
 
 // Flight Create Orders
-// Books the flight-offer(s) returned by the Flight Offers Price
-// and creates a flight-order with travelers' information.
+// To book the flight-offer(s) returned by the Flight Offers Price
+// and create a flight-order with travelers' information.
 // A full example can be found at https://git.io/JtnYo
 amadeus.booking.flightOrders.post(
   JSON.stringify({

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var amadeus = new Amadeus({
 amadeus.shopping.flightOffersSearch.get({
     originLocationCode: 'SYD',
     destinationLocationCode: 'BKK',
-    departureDate: '2021-04-01',
+    departureDate: '2021-08-01',
     adults: '2'
 }).then(function(response){
   console.log(response.data);
@@ -188,9 +188,46 @@ amadeus.shopping.flightDates.get({
 amadeus.shopping.flightOffersSearch.get({
   originLocationCode: 'SYD',
   destinationLocationCode: 'BKK',
-  departureDate: '2021-04-01',
+  departureDate: '2021-08-01',
   adults: '2'
 })
+
+// Flight Offers Price
+amadeus.shopping.flightOffersSearch.get({
+    originLocationCode: 'SYD',
+    destinationLocationCode: 'BKK',
+    departureDate: '2021-08-01',
+    adults: '1'
+}).then(function(response){
+    return amadeus.shopping.flightOffers.pricing.post(
+      JSON.stringify({
+        'data': {
+          'type': 'flight-offers-pricing',
+          'flightOffers': [response.data[0]]
+        }
+      })
+    )
+}).then(function(response){
+    console.log(response.data);
+}).catch(function(responseError){
+    console.log(responseError);
+});
+
+// Flight Create Orders
+// To book the flight-offer(s) returned by the Flight Offers Price
+// and create a flight-order with travelers' information
+amadeus.booking.flightOrders.post(
+  JSON.stringify({
+    'type': 'flight-order',
+    'flightOffers': [priced-offers],
+    'travelers': []
+  })
+);
+}).then(function(response){
+    console.log(response.data);
+}).catch(function(responseError){
+    console.log(responseError);
+});
 
 // Flight Choice Prediction
 amadeus.shopping.flightOffersSearch.get({
@@ -208,57 +245,13 @@ amadeus.shopping.flightOffersSearch.get({
     console.log(responseError);
 });
 
-
-// Flight Create Orders
-// To book the flight-offer(s) suggested by flightOffersSearch API
-// and create a flight-order with travelers' information
-amadeus.shopping.flightOffersSearch.get({
-    originLocationCode: 'SYD',
-    destinationLocationCode: 'BKK',
-    departureDate: '2021-04-01',
-    adults: '1'
-}).then(function(response){
-    return amadeus.booking.flightOrders.post(
-      JSON.stringify({
-        'type': 'flight-order',
-        'flightOffers': response.flightOffers,
-        'travelers_info': []
-      })
-    );
-}).then(function(response){
-    console.log(response.data);
-}).catch(function(responseError){
-    console.log(responseError);
-});
-
-// Flight Offers 
-amadeus.shopping.flightOffersSearch.get({
-    originLocationCode: 'SYD',
-    destinationLocationCode: 'BKK',
-    departureDate: '2021-04-01',
-    adults: '1'
-}).then(function(response){
-    return amadeus.shopping.flightOffers.pricing.post(
-      JSON.stringify({
-        'data': {
-          'type': 'flight-offers-pricing',
-          'flightOffers': [response.data[0]]
-        }
-      })
-    )
-}).then(function(response){
-    console.log(response.data);
-}).catch(function(responseError){
-    console.log(responseError);
-});
-
 // Flight SeatMap Display
 // To retrieve the seat map of each flight included
-// in flight offers for MAD-NYC flight on 2020-08-01
+// in flight offers for MAD-NYC flight on 2021-08-01
 amadeus.shopping.flightOffersSearch.get({
   originLocationCode: 'SYD',
   destinationLocationCode: 'BKK',
-  departureDate: '2021-04-01',
+  departureDate: '2021-08-01',
   adults: '1'
 }).then(function(response){
     return amadeus.shopping.seatmaps.post(
@@ -468,7 +461,7 @@ amadeus.travel.predictions.flightDelay.get({
 // Get the percentage of on-time flight departures from JFK
 amadeus.airport.predictions.onTime.get({
   airportCode: 'JFK',
-  date: '2020-08-01'
+  date: '2021-08-01'
 })
 
 // Travel Recommendations

--- a/README.md
+++ b/README.md
@@ -223,12 +223,7 @@ amadeus.booking.flightOrders.post(
     'flightOffers': [priced-offers],
     'travelers': []
   })
-);
-}).then(function(response){
-    console.log(response.data);
-}).catch(function(responseError){
-    console.log(responseError);
-});
+)
 
 // Retrieve flight order with ID 'XXX'. This ID comes from the
 // Flight Create Orders API, which is a temporary ID in test environment.

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ amadeus.shopping.flightOffersSearch.get({
 });
 
 // Flight Create Orders
-// To book the flight-offer(s) returned by the Flight Offers Price
-// and create a flight-order with travelers' information
+// Books the flight-offer(s) returned by the Flight Offers Price
+// and creates a flight-order with travelers' information.
+// A full example can be found at https://git.io/JtnYo
 amadeus.booking.flightOrders.post(
   JSON.stringify({
     'type': 'flight-order',


### PR DESCRIPTION
- Updates Flight Create Orders in readme and mention it takes as input the flights coming from the Flight Offers Price API (instead of the Flight Offers Search)
- Adds shortened URL to Flight Create Orders node example
- Reorders flight APIs in list of supported endpoints
- Updates past dates