### PR TITLE
Fix 204 parser exception and add test

### DIFF
--- a/spec/amadeus/client/response.test.js
+++ b/spec/amadeus/client/response.test.js
@@ -55,6 +55,15 @@ describe('Response', () => {
         expect(response.data).toBeNull();
       });
 
+      it('should not parse if status code is 204', () => {
+        response.contentType = 'plain/text';
+        response.statusCode = 204;
+        response.parse();
+        expect(response.parsed).toBeFalsy();
+        expect(response.result).toBeNull();
+        expect(response.data).toBeNull();
+      });
+
       it('should handle badly formed json', () => {
         response.addChunk('{ "a" : ');
         response.parse();
@@ -65,6 +74,12 @@ describe('Response', () => {
     });
 
     describe('.success', () => {
+      it('be true if the document was not parsed with a 204 status code', () => {
+        response.statusCode = 204;
+        response.parsed = false;
+        expect(response.success()).toBeTruthy();
+      });
+
       it('be true if the document was parsed and with a 2XX status code', () => {
         response.statusCode = 201;
         response.parsed = true;
@@ -77,7 +92,7 @@ describe('Response', () => {
         expect(response.success()).toBeFalsy();
       });
 
-      it('be false if the document was not parsed and with a 2XX status code', () => {
+      it('be false if the document was not parsed and with a 2XX status code excluding 204', () => {
         response.statusCode = 201;
         response.parsed = false;
         expect(response.success()).toBeFalsy();

--- a/src/amadeus/client/response.js
+++ b/src/amadeus/client/response.js
@@ -45,6 +45,9 @@ class Response {
    */
   parse() {
     try {
+      if (this.statusCode == 204) {
+        return;
+      }
       if (this.isJson()) {
         this.result = JSON.parse(this.body);
         this.data = this.result.data;
@@ -65,7 +68,12 @@ class Response {
    * @protected
    */
   success() {
-    return (this.parsed && this.statusCode < 300);
+    if (this.statusCode == 204) {
+      return true;
+    }
+    if (this.parsed && this.statusCode < 300) {
+      return true;
+    }
   }
 
   // PRIVATE


### PR DESCRIPTION
The Flight Orders Management API returns en empty body with status code 204 when an order is deleted successfully. The SDK doesn't handle this use case properly; it throws a ParserException as the API does not return a FlightOrder object but instead returns the empty response with code 204.