### PR TITLE
Client init without parameters

### DIFF
--- a/spec/amadeus/client/validator.test.js
+++ b/spec/amadeus/client/validator.test.js
@@ -31,11 +31,14 @@ describe('Validator', () => {
         'test1' : '1'
       };
       process.env.AMADEUS_TEST2 = '2';
+      process.env.AMADEUS_TEST_SNAKE_CASE = '5';
       expect(validator.initOptional('test1', options)).toBe('1');
       expect(validator.initOptional('test2', options)).toBe('2');
       expect(validator.initOptional('test3', options)).toBe(null);
       expect(validator.initOptional('test4', options, '4')).toBe('4');
+      expect(validator.initOptional('testSnakeCase', options)).toBe('5');
       process.env.AMADEUS_TEST2 = undefined;
+      process.env.AMADEUS_TEST_SNAKE_CASE = undefined;
     });
   });
 

--- a/src/amadeus/client/validator.js
+++ b/src/amadeus/client/validator.js
@@ -81,7 +81,8 @@ class Validator {
 
   initOptional(key, options, fallback = null) {
     let value = options[key];
-    let envKey = `AMADEUS_${key.toUpperCase()}`;
+    //Env variables names expected to be in SNAKE_CASE and uppercase
+    let envKey = `AMADEUS_${key.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`).toUpperCase()}`;
     if (value == undefined) { value = options[key]; }
     if (value == undefined) { value = process.env[envKey]; }
     if (value == undefined) { value = fallback; }


### PR DESCRIPTION
Fixes #
Fixed the initialization of a client without parameters.
Environment variables are expected to be uppercase SNAKE_CASE, while app was reading them as if they were camelCase.

## Changes for this pull request
A conversion method was added to read environment variables successfully. 
Added a test to ensure SNAKE_CASE variables are correctly read
