### PR TITLE
Release version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 7.0.0 - 2022-07-19
-Decommission Trip Parser API V2 
+Decommission Trip Parser API v2 
 
 Update versions of dependencies
 - @babel/cli from ^7.4.4 to ^7.18.6
@@ -18,7 +18,7 @@ Add support for the [Hotel Name Autocomplete API](https://developers.amadeus.com
 
 Add support for the [Airline Routes API](https://developers.amadeus.com/self-service/category/air/api-doc/airline-routes/api-reference)
 
-Add support for the [Trip Parser API V3](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-parser/api-reference)
+Add support for the [Trip Parser API v3](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-parser/api-reference)
 
 ## 6.0.0 - 2022-05-20
 Decommission AI-Generated Photos API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 7.0.0 - 2022-07-19
+Decommission Trip Parser API V2 
+
+Update versions of dependencies
+- @babel/cli from ^7.4.4 to ^7.18.6
+- @babel/core from ^7.4.5 to ^7.18.6
+- @babel/preset-env from ^7.4.5 to ^7.18.6
+- babel-plugin-add-module-exports from ^0.2.1 to ^1.0.4
+- documentation from ^11.0.0 to ^13.2.5
+- bluebird from ^3.5.1 to ^3.7.2
+- qs from ^6.9.1 to ^6.11.0
+
+Add support for the [City Search API](https://developers.amadeus.com/self-service/category/trip/api-doc/city-search/api-reference)
+
+Add support for the [Hotel Name Autocomplete API](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-name-autocomplete/api-reference)
+
+Add support for the [Airline Routes API](https://developers.amadeus.com/self-service/category/air/api-doc/airline-routes/api-reference)
+
+Add support for the [Trip Parser API V3](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-parser/api-reference)
+
 ## 6.0.0 - 2022-05-20
 Decommission AI-Generated Photos API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amadeus",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Node library for the Amadeus travel APIs",
   "main": "lib/amadeus.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amadeus",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Node library for the Amadeus travel APIs",
   "main": "lib/amadeus.js",
   "scripts": {


### PR DESCRIPTION
Decommission Trip Parser API V2 

Update versions of dependencies
- @babel/cli from ^7.4.4 to ^7.18.6
- @babel/core from ^7.4.5 to ^7.18.6
- @babel/preset-env from ^7.4.5 to ^7.18.6
- babel-plugin-add-module-exports from ^0.2.1 to ^1.0.4
- documentation from ^11.0.0 to ^13.2.5
- bluebird from ^3.5.1 to ^3.7.2
- qs from ^6.9.1 to ^6.11.0

Add support for the [City Search API](https://developers.amadeus.com/self-service/category/trip/api-doc/city-search/api-reference)

Add support for the [Hotel Name Autocomplete API](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-name-autocomplete/api-reference)

Add support for the [Airline Routes API](https://developers.amadeus.com/self-service/category/air/api-doc/airline-routes/api-reference)

Add support for the [Trip Parser API V3](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-parser/api-reference)