### PR TITLE
Add Cars & Transfers APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,14 +544,13 @@ amadeus.dutyOfCare.diseases.covid19Report.get({
 
 //Car & Transfers APIs
 // Transfer Search API : Search Transfer offers 
-amadeus.shopping.transferOffers.post(
-  JSON.stringify(body));
+amadeus.shopping.transferOffers.post(JSON.stringify(body));
 
-// Transfer Book API : Book a transfer based on an offer id
+// Transfer Book API : Book a transfer based on the offer id
 amadeus.ordering.transferOrders.post(JSON.stringify(body),offerId='2094123123');
 
-// Transfer Management API : Cancel a transfer based on an order id
-amadeus.ordering.transferOrders('XXX').transfers.cancellation.post(JSON.stringify({}), confirmNbr=12345);
+// Transfer Management API : Cancel a transfer based on the order id & confirmation number
+amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), confirmNbr='12345');
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -542,14 +542,14 @@ amadeus.dutyOfCare.diseases.covid19Report.get({
   language: 'EN'
 });
 
-//Car & Transfers APIs
-// Transfer Search API : Search Transfer offers 
+//Cars & Transfers APIs
+// Transfer Search API: Search Transfer
 amadeus.shopping.transferOffers.post(JSON.stringify(body));
 
-// Transfer Book API : Book a transfer based on the offer id
+// Transfer Book API: Book a transfer based on the offer id
 amadeus.ordering.transferOrders.post(JSON.stringify(body),offerId='2094123123');
 
-// Transfer Management API : Cancel a transfer based on the order id & confirmation number
+// Transfer Management API: Cancel a transfer based on the order id & confirmation number
 amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), confirmNbr='12345');
 
 ```

--- a/README.md
+++ b/README.md
@@ -542,6 +542,17 @@ amadeus.dutyOfCare.diseases.covid19Report.get({
   language: 'EN'
 });
 
+//Car & Transfers APIs
+// Transfer Search API : Search Transfer offers 
+amadeus.shopping.transferOffers.post(
+  JSON.stringify(body));
+
+// Transfer Book API : Book a transfer based on an offer id
+amadeus.ordering.transferOrders.post(JSON.stringify(body),offerId='2094123123');
+
+// Transfer Management API : Cancel a transfer based on an order id
+amadeus.ordering.transferOrders('XXX').transfers.cancellation.post(JSON.stringify({}), confirmNbr=12345);
+
 ```
 
 ## Development & Contributing

--- a/spec/amadeus/namespaces.test.js
+++ b/spec/amadeus/namespaces.test.js
@@ -85,7 +85,7 @@ describe('Namespaces', () => {
 
       expect(amadeus.ordering).toBeDefined();
       expect(amadeus.ordering.transferOrders).toBeDefined();
-      expect(amadeus.ordering.transferOffers('XXX').transfers.cancellation).toBeDefined();
+      expect(amadeus.ordering.transferOrder('XXX').transfers.cancellation).toBeDefined();
 
       expect(amadeus.airport).toBeDefined();
       expect(amadeus.airport.directDestinations).toBeDefined();
@@ -173,7 +173,7 @@ describe('Namespaces', () => {
       expect(amadeus.booking.hotelBookings.post).toBeDefined();
       expect(amadeus.shopping.transferOffers.post).toBeDefined();
       expect(amadeus.ordering.transferOrders.post).toBeDefined();
-      expect(amadeus.ordering.transferOrders('XXX').transfers.cancellation.post).toBeDefined();
+      expect(amadeus.ordering.transferOrder('XXX').transfers.cancellation.post).toBeDefined();
     });
 
     it('should define all expected .delete methods', () => {
@@ -555,16 +555,16 @@ describe('Namespaces', () => {
 
     it('.amadeus.ordering.transferOrders.post', () => {
       amadeus.client.post = jest.fn();
-      amadeus.shopping.transferOrders.post();
+      amadeus.ordering.transferOrders.post({}, '1234123123');
       expect(amadeus.client.post)
-        .toHaveBeenCalledWith('/v1/shopping/transfer-orders', {});
+        .toHaveBeenCalledWith('/v1/ordering/transfer-orders?offerId=1234123123', {});
     });
 
     it('.amadeus.ordering.transferOrders().transfers.cancellation.post', () => {
       amadeus.client.post = jest.fn();
-      amadeus.shopping.transferOrders(XXX).transfers.cancellation.post();
+      amadeus.ordering.transferOrder('XXX').transfers.cancellation.post({}, 12345);
       expect(amadeus.client.post)
-        .toHaveBeenCalledWith('/v1/shopping/transfer-orders/XXX/transfers/cancellation', {});
+        .toHaveBeenCalledWith('/v1/ordering/transfer-orders/XXX/transfers/cancellation?confirmNbr=12345', {});
     });
 
   });

--- a/spec/amadeus/namespaces.test.js
+++ b/spec/amadeus/namespaces.test.js
@@ -72,6 +72,8 @@ describe('Namespaces', () => {
       expect(amadeus.shopping.availability).toBeDefined();
       expect(amadeus.shopping.availability.flightAvailabilities).toBeDefined();
 
+      expect(amadeus.shopping.transferOffers).toBeDefined();
+
       expect(amadeus.booking.flightOrder).toBeDefined();
       expect(amadeus.booking.hotelBookings).toBeDefined();
 
@@ -80,6 +82,10 @@ describe('Namespaces', () => {
 
       expect(amadeus.media).toBeDefined();
       expect(amadeus.media.files).toBeDefined();
+
+      expect(amadeus.ordering).toBeDefined();
+      expect(amadeus.ordering.transferOrders).toBeDefined();
+      expect(amadeus.ordering.transferOffers('XXX').transfers.cancellation).toBeDefined();
 
       expect(amadeus.airport).toBeDefined();
       expect(amadeus.airport.directDestinations).toBeDefined();
@@ -165,6 +171,9 @@ describe('Namespaces', () => {
       expect(amadeus.shopping.flightOffers.pricing.post).toBeDefined();
       expect(amadeus.shopping.seatmaps.post).toBeDefined();
       expect(amadeus.booking.hotelBookings.post).toBeDefined();
+      expect(amadeus.shopping.transferOffers.post).toBeDefined();
+      expect(amadeus.ordering.transferOrders.post).toBeDefined();
+      expect(amadeus.ordering.transferOrders('XXX').transfers.cancellation.post).toBeDefined();
     });
 
     it('should define all expected .delete methods', () => {
@@ -535,6 +544,27 @@ describe('Namespaces', () => {
       amadeus.airline.destinations.get();
       expect(amadeus.client.get)
         .toHaveBeenCalledWith('/v1/airline/destinations', {});
+    });
+
+    it('.amadeus.shopping.transferOffers.post', () => {
+      amadeus.client.post = jest.fn();
+      amadeus.shopping.transferOffers.post();
+      expect(amadeus.client.post)
+        .toHaveBeenCalledWith('/v1/shopping/transfer-offers', {});
+    });
+
+    it('.amadeus.ordering.transferOrders.post', () => {
+      amadeus.client.post = jest.fn();
+      amadeus.shopping.transferOrders.post();
+      expect(amadeus.client.post)
+        .toHaveBeenCalledWith('/v1/shopping/transfer-orders', {});
+    });
+
+    it('.amadeus.ordering.transferOrders().transfers.cancellation.post', () => {
+      amadeus.client.post = jest.fn();
+      amadeus.shopping.transferOrders(XXX).transfers.cancellation.post();
+      expect(amadeus.client.post)
+        .toHaveBeenCalledWith('/v1/shopping/transfer-orders/XXX/transfers/cancellation', {});
     });
 
   });

--- a/src/amadeus.js
+++ b/src/amadeus.js
@@ -7,6 +7,7 @@ import Booking       from './amadeus/namespaces/booking';
 import Travel        from './amadeus/namespaces/travel';
 import EReputation   from './amadeus/namespaces/e_reputation';
 import Media         from './amadeus/namespaces/media';
+import Ordering      from './amadeus/namespaces/ordering';
 import Airport       from './amadeus/namespaces/airport';
 import Safety        from './amadeus/namespaces/safety';
 import Schedule      from './amadeus/namespaces/schedule';
@@ -72,6 +73,7 @@ class Amadeus {
     this.travel         = new Travel(this.client);
     this.eReputation    = new EReputation(this.client);
     this.media          = new Media(this.client);
+    this.ordering       = new Ordering(this.client);
     this.airport        = new Airport(this.client);
     this.pagination     = new Pagination(this.client);
     this.safety         = new Safety(this.client);

--- a/src/amadeus/namespaces/ordering.js
+++ b/src/amadeus/namespaces/ordering.js
@@ -1,4 +1,5 @@
 import TransferOrders from './ordering/transfer_orders';
+import TransferOrder from './ordering/transfer_order';
 
 /**
  * A namespaced client for the
@@ -12,17 +13,14 @@ import TransferOrders from './ordering/transfer_orders';
  * ```
  *
  * @param {Client} client
- * @property {TransferOrders} TransferOrders
- * @protected
+ * @property {TransferOrders} transferOrders
+ * @property {TransferOrder} transferOrder
  */
 class Ordering {
   constructor(client) {
-    this.client    = client;
+    this.client = client;
     this.transferOrders = new TransferOrders(client);
-  }
-
-  transferOrders (offerId) {
-    return new TransferOrders(this.client, offerId);
+    this.transferOrder = (orderId) => new TransferOrder(client, orderId);
   }
 }
 

--- a/src/amadeus/namespaces/ordering.js
+++ b/src/amadeus/namespaces/ordering.js
@@ -1,0 +1,29 @@
+import TransferOrders from './ordering/transfer_orders';
+
+/**
+ * A namespaced client for the
+ * `/v1/ordering` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.ordering;
+ * ```
+ *
+ * @param {Client} client
+ * @property {TransferOrders} TransferOrders
+ * @protected
+ */
+class Ordering {
+  constructor(client) {
+    this.client    = client;
+    this.transferOrders = new TransferOrders(client);
+  }
+
+  transferOrders (offerId) {
+    return new TransferOrders(this.client, offerId);
+  }
+}
+
+export default Ordering;

--- a/src/amadeus/namespaces/ordering/transfer_order.js
+++ b/src/amadeus/namespaces/ordering/transfer_order.js
@@ -1,0 +1,25 @@
+import Transfers from './transfer_orders/transfers';
+
+/**
+ * A namespaced client for the
+ * `/v1/ordering/transfer-orders/XXXXX` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.ordering.transferOrder('XXX');
+ * ```
+ *
+ * @param {Client} client
+ * @param {string} orderId
+ */
+class TransferOrder {
+  constructor(client, orderId) {
+    this.client = client;
+    this.orderId = orderId;
+    this.transfers = new Transfers(client, orderId);
+  }
+}
+
+export default TransferOrder;

--- a/src/amadeus/namespaces/ordering/transfer_orders.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders.js
@@ -1,0 +1,39 @@
+/**
+ * A namespaced client for the
+ * `/v1/ordering/transfer-orders` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.ordering.transferOrders;
+ * ```
+ *
+ * @param {Client} client
+ */
+class TransferOrders {
+    constructor(client) {
+      this.client = client;
+      this.offerId = offerId;
+    }
+  
+    /**
+     * To book the selected transfer-offer and create a transfer-order
+     *
+     * @param {Object} params
+     * @return {Promise.<Response,ResponseError>} a Promise
+     *
+     * To book the transfer-offer(s) suggested by transferOffers and create a transfer-order
+     *
+     * ```js
+     * amadeus.ordering.transferOrders.post(JSON.stringify(body),offerId='2094123123');
+     * ```
+     */
+    post(params = {}) {
+      return this.client.post(
+        `/v1/ordering/transfer-orders/${this.offerId}`, params
+      );
+    }
+  }
+  
+  export default TransferOrders;

--- a/src/amadeus/namespaces/ordering/transfer_orders.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders.js
@@ -12,28 +12,25 @@
  * @param {Client} client
  */
 class TransferOrders {
-    constructor(client) {
-      this.client = client;
-      this.offerId = offerId;
-    }
-  
-    /**
-     * To book the selected transfer-offer and create a transfer-order
-     *
-     * @param {Object} params
-     * @return {Promise.<Response,ResponseError>} a Promise
-     *
-     * To book the transfer-offer(s) suggested by transferOffers and create a transfer-order
-     *
-     * ```js
-     * amadeus.ordering.transferOrders.post(JSON.stringify(body),offerId='2094123123');
-     * ```
-     */
-    post(params = {}) {
-      return this.client.post(
-        `/v1/ordering/transfer-orders/${this.offerId}`, params
-      );
-    }
+  constructor(client) {
+    this.client = client;
+
   }
-  
-  export default TransferOrders;
+
+  /**
+   * To book the selected transfer-offer and create a transfer-order
+   *
+   * @return {Promise.<Response,ResponseError>} a Promise
+   *
+   * To book the transfer-offer(s) suggested by transferOffers and create a transfer-order
+   *
+   * ```js
+   * amadeus.ordering.transferOrders.post(body, '2094123123');;
+   * ```
+   */
+  post(body, offerId) {
+    return this.client.post(`/v1/ordering/transfer-orders?offerId=${offerId}`, body);
+  }
+}
+
+export default TransferOrders;

--- a/src/amadeus/namespaces/ordering/transfer_orders/transfers.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders/transfers.js
@@ -14,10 +14,11 @@ import Cancellation from './transfers/cancellation';
  * @param {Client} client
  */
 class Transfers {
-    constructor(client) {
-      this.client = client;
-      this.cancellation = new Cancellation(client);
-    }
+  constructor(client, orderId) {
+    this.client = client;
+    this.orderId = orderId;
+    this.cancellation = new Cancellation(client, orderId);
   }
-  
-  export default Transfers;
+}
+
+export default Transfers;

--- a/src/amadeus/namespaces/ordering/transfer_orders/transfers.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders/transfers.js
@@ -1,0 +1,23 @@
+import Cancellation from './transfers/cancellation';
+
+/**
+ * A namespaced client for the
+ * `/v1/ordering/transfer-orders/XXXXX/transfers` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.ordering.transferOrders('XXX').transfers;
+ * ```
+ *
+ * @param {Client} client
+ */
+class Transfers {
+    constructor(client) {
+      this.client = client;
+      this.cancellation = new Cancellation(client);
+    }
+  }
+  
+  export default Transfers;

--- a/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
@@ -1,0 +1,37 @@
+/**
+ * A namespaced client for the
+ * `/v1/ordering/transfer-orders/XXX/transfers/cancellation` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(body, confirmNbr=123);
+ * ```
+ *
+ * @param {Client} client
+ */
+class TransferOrder {
+    constructor(client) {
+      this.client = client;
+      this.orderId = orderId;
+    }
+  
+    /**
+     * To retrieve a transfer order based on its id
+     * @param {Object} params
+     * @return {Promise.<Response,ResponseError>} a Promise
+     *
+     * To retrieve a transfer order with ID 'XXX'
+     *
+     * ```js
+     * amadeus.ordering.transferOrders('XXX').transfers.cancellation.post({}, confirmNbr=123);
+     * ```
+     */
+    post(params = {}) {
+      return this.client.post(
+        `/v1/ordering/transfer-orders/${this.orderId}/transfers/cancellation`, params);
+    }
+  }
+  
+  export default TransferOrder;

--- a/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
@@ -6,32 +6,31 @@
  *
  * ```js
  * let amadeus = new Amadeus();
- * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(body, confirmNbr=123);
+ * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), 12345);;
  * ```
  *
  * @param {Client} client
  */
-class TransferOrder {
-    constructor(client) {
-      this.client = client;
-      this.orderId = orderId;
-    }
-  
-    /**
-     * To retrieve a transfer order based on its id
-     * @param {Object} params
-     * @return {Promise.<Response,ResponseError>} a Promise
-     *
-     * To retrieve a transfer order with ID 'XXX'
-     *
-     * ```js
-     * amadeus.ordering.transferOrders('XXX').transfers.cancellation.post({}, confirmNbr=123);
-     * ```
-     */
-    post(params = {}) {
-      return this.client.post(
-        `/v1/ordering/transfer-orders/${this.orderId}/transfers/cancellation`, params);
-    }
+class Cancellation {
+  constructor(client, orderId) {
+    this.client = client;
+    this.orderId = orderId;
   }
-  
-  export default TransferOrder;
+
+  /**
+   * To cancel a transfer order based on its id
+   * @return {Promise.<Response,ResponseError>} a Promise
+   *
+   * To cancel a transfer order with ID 'XXX' and confirmation number '12345'
+   *
+   * ```js
+   * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), 12345);;
+   * ```
+   */
+  post(body, confirmNbr) {
+    return this.client.post(
+      `/v1/ordering/transfer-orders/${this.orderId}/transfers/cancellation?confirmNbr=${confirmNbr}`, body);
+  }
+}
+
+export default Cancellation;

--- a/src/amadeus/namespaces/shopping.js
+++ b/src/amadeus/namespaces/shopping.js
@@ -8,7 +8,7 @@ import HotelOffersSearch  from './shopping/hotel_offers_search';
 import Activities         from './shopping/activities';
 import Activity           from './shopping/activity';
 import Availability       from './shopping/availability';
-
+import TransferOffers     from './shopping/transfer_offers';
 
 /**
  * A namespaced client for the
@@ -30,6 +30,7 @@ import Availability       from './shopping/availability';
  * @property {HotelOfferSearch} hotelOffers
  * @property {HotelOffersSearch} hotelOffers
  * @property {Availability} availability
+ * @property {TransferOffers} transferOffers
  */
 class Shopping {
   constructor(client) {
@@ -42,6 +43,7 @@ class Shopping {
     this.hotelOffersSearch  = new HotelOffersSearch(client);
     this.activities         = new Activities(client);
     this.availability       = new Availability(client);
+    this.transferOffers     = new TransferOffers(client);
   }
 
   /**

--- a/src/amadeus/namespaces/shopping/hotel_offer_search.js
+++ b/src/amadeus/namespaces/shopping/hotel_offer_search.js
@@ -12,7 +12,7 @@
  * @param {Client} client
  * @property {number} offerId
  */
-class hotelOfferSearch {
+class HotelOfferSearch {
   constructor(client, offerId) {
     this.client = client;
     this.offerId = offerId;
@@ -37,4 +37,4 @@ class hotelOfferSearch {
   }
 }
 
-export default hotelOfferSearch;
+export default HotelOfferSearch;

--- a/src/amadeus/namespaces/shopping/hotel_offers_search.js
+++ b/src/amadeus/namespaces/shopping/hotel_offers_search.js
@@ -11,7 +11,7 @@
  *
  * @param {Client} client
  */
-class hotelOffersSearch {
+class HotelOffersSearch {
   constructor(client) {
     this.client = client;
   }
@@ -39,4 +39,4 @@ class hotelOffersSearch {
   }
 }
 
-export default hotelOffersSearch;
+export default HotelOffersSearch;

--- a/src/amadeus/namespaces/shopping/transfer_offers.js
+++ b/src/amadeus/namespaces/shopping/transfer_offers.js
@@ -13,73 +13,26 @@
  * @param {Client} client
  */
 class TransferOffers {
-    constructor(client) {
-      this.client = client;
-    }
-  
-    /**
-     * To search .
-     *
-     * @param {Object} params
-     * @return {Promise.<Response,ResponseError>} a Promise
-     *
-     * To search the list of transfer offers
-     *
-     * ```js
-     * amadeus.shopping.transferOffers.post (JSON.stringify({
-        "startLocationCode": "CDG",
-        "endAddressLine": "Avenue Anatole France, 5",
-        "endCityName": "Paris",
-        "endZipCode": "75007",
-        "endCountryCode": "FR",
-        "endName": "Souvenirs De La Tour",
-        "endGeoCode": "48.859466,2.2976965",
-        "transferType": "PRIVATE",
-        "startDateTime": "2023-11-10T10:30:00",
-        "providerCodes": "TXO",
-        "passengers": 2,
-        "stopOvers": [
-            {
-            "duration": "PT2H30M",
-            "sequenceNumber": 1,
-            "addressLine": "Avenue de la Bourdonnais, 19",
-            "countryCode": "FR",
-            "cityName": "Paris",
-            "zipCode": "75007",
-            "name": "De La Tours",
-            "geoCode": "48.859477,2.2976985",
-            "stateCode": "FR"
-            }
-        ],
-        "startConnectedSegment": {
-            "transportationType": "FLIGHT",
-            "transportationNumber": "AF380",
-            "departure": {
-            "localDateTime": "2023-11-10T09:00:00",
-            "iataCode": "NCE"
-            },
-            "arrival": {
-            "localDateTime": "2023-11-10T10:00:00",
-            "iataCode": "CDG"
-            }
-        },
-        "passengerCharacteristics": [
-            {
-            "passengerTypeCode": "ADT",
-            "age": 20
-            },
-            {
-            "passengerTypeCode": "CHD",
-            "age": 10
-            }
-        ]
-        }
-     * ```
-    */
-    post(params = {}) {
-      return this.client.post('/v1/shopping/transfer-offers', params);
-    }
-  
+  constructor(client) {
+    this.client = client;
   }
-  
-  export default TransferOffers;
+
+  /**
+   * To search the list of transfer offers.
+   *
+   * @param {Object} params
+   * @return {Promise.<Response,ResponseError>} a Promise
+   *
+   * To search the list of transfer offers
+   *
+   * ```js
+   * amadeus.shopping.transferOffers.post(body)
+
+   * ```
+  */
+  post(params = {}) {
+    return this.client.post('/v1/shopping/transfer-offers', params);
+  }
+}
+
+export default TransferOffers;

--- a/src/amadeus/namespaces/shopping/transfer_offers.js
+++ b/src/amadeus/namespaces/shopping/transfer_offers.js
@@ -1,0 +1,85 @@
+
+/**
+ * A namespaced client for the
+ * `/v1/shopping/transfer-offers` endpoints
+ *
+ * Access via the {@link Amadeus} object
+ *
+ * ```js
+ * let amadeus = new Amadeus();
+ * amadeus.shopping.transferOffers;
+ * ```
+ *
+ * @param {Client} client
+ */
+class TransferOffers {
+    constructor(client) {
+      this.client = client;
+    }
+  
+    /**
+     * To search .
+     *
+     * @param {Object} params
+     * @return {Promise.<Response,ResponseError>} a Promise
+     *
+     * To search the list of transfer offers
+     *
+     * ```js
+     * amadeus.shopping.transferOffers.post (JSON.stringify({
+        "startLocationCode": "CDG",
+        "endAddressLine": "Avenue Anatole France, 5",
+        "endCityName": "Paris",
+        "endZipCode": "75007",
+        "endCountryCode": "FR",
+        "endName": "Souvenirs De La Tour",
+        "endGeoCode": "48.859466,2.2976965",
+        "transferType": "PRIVATE",
+        "startDateTime": "2023-11-10T10:30:00",
+        "providerCodes": "TXO",
+        "passengers": 2,
+        "stopOvers": [
+            {
+            "duration": "PT2H30M",
+            "sequenceNumber": 1,
+            "addressLine": "Avenue de la Bourdonnais, 19",
+            "countryCode": "FR",
+            "cityName": "Paris",
+            "zipCode": "75007",
+            "name": "De La Tours",
+            "geoCode": "48.859477,2.2976985",
+            "stateCode": "FR"
+            }
+        ],
+        "startConnectedSegment": {
+            "transportationType": "FLIGHT",
+            "transportationNumber": "AF380",
+            "departure": {
+            "localDateTime": "2023-11-10T09:00:00",
+            "iataCode": "NCE"
+            },
+            "arrival": {
+            "localDateTime": "2023-11-10T10:00:00",
+            "iataCode": "CDG"
+            }
+        },
+        "passengerCharacteristics": [
+            {
+            "passengerTypeCode": "ADT",
+            "age": 20
+            },
+            {
+            "passengerTypeCode": "CHD",
+            "age": 10
+            }
+        ]
+        }
+     * ```
+    */
+    post(params = {}) {
+      return this.client.post('/v1/shopping/transfer-offers', params);
+    }
+  
+  }
+  
+  export default TransferOffers;


### PR DESCRIPTION
1. Added Support for [Transfer Search API](https://developers.amadeus.com/self-service/category/cars-and-transfers/api-doc/transfer-search/api-reference).
2. Added Support for [Transfer Booking API](https://developers.amadeus.com/self-service/category/cars-and-transfers/api-doc/transfer-booking/api-reference)./
3. Added Support for [Transfer Management API](https://developers.amadeus.com/self-service/category/cars-and-transfers/api-doc/transfer-management/api-reference).
4. Added relevant comments and tests.