### PR TITLE
support add parameter in flight offer price and JSON.stringify for all post methods

### DIFF
--- a/src/amadeus/namespaces/booking/flight_orders.js
+++ b/src/amadeus/namespaces/booking/flight_orders.js
@@ -33,7 +33,7 @@ class FlightOrders {
    * ```
    */
   post(params = {}) {
-    return this.client.post('/v1/booking/flight-orders', params);
+    return this.client.post('/v1/booking/flight-orders', JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/ordering/transfer_orders.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders.js
@@ -29,7 +29,7 @@ class TransferOrders {
    * ```
    */
   post(body, offerId) {
-    return this.client.post(`/v1/ordering/transfer-orders?offerId=${offerId}`, body);
+    return this.client.post(`/v1/ordering/transfer-orders?offerId=${offerId}`, JSON.stringify(body));
   }
 }
 

--- a/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
+++ b/src/amadeus/namespaces/ordering/transfer_orders/transfers/cancellation.js
@@ -6,7 +6,7 @@
  *
  * ```js
  * let amadeus = new Amadeus();
- * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), 12345);;
+ * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post({}, '12345');;
  * ```
  *
  * @param {Client} client
@@ -24,12 +24,12 @@ class Cancellation {
    * To cancel a transfer order with ID 'XXX' and confirmation number '12345'
    *
    * ```js
-   * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post(JSON.stringify({}), 12345);;
+   * amadeus.ordering.transferOrder('XXX').transfers.cancellation.post({}, '12345');;
    * ```
    */
   post(body, confirmNbr) {
     return this.client.post(
-      `/v1/ordering/transfer-orders/${this.orderId}/transfers/cancellation?confirmNbr=${confirmNbr}`, body);
+      `/v1/ordering/transfer-orders/${this.orderId}/transfers/cancellation?confirmNbr=${confirmNbr}`, JSON.stringify(body));
   }
 }
 

--- a/src/amadeus/namespaces/shopping/availability/flight_availabilities.js
+++ b/src/amadeus/namespaces/shopping/availability/flight_availabilities.js
@@ -27,7 +27,7 @@ class FlightAvailabilities {
    * ```
    */
   post(params = {}) {
-    return this.client.post('/v1/shopping/availability/flight-availabilities', params);
+    return this.client.post('/v1/shopping/availability/flight-availabilities', JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/shopping/flight_offers/pricing.js
+++ b/src/amadeus/namespaces/shopping/flight_offers/pricing.js
@@ -38,8 +38,20 @@ class Pricing {
    * });
    * ```
    */
-  post(params = {}) {
-    return this.client.post('/v1/shopping/flight-offers/pricing', params);
+  post(params = {}, additionalParams = {}) {
+    // Check if params is an array
+    if (Array.isArray(params)) {
+      // If it is, wrap it in the required structure
+      params = {
+        'data': {
+          'type': 'flight-offers-pricing',
+          'flightOffers': params
+        }
+      };
+    }
+    // Convert additionalParams object to query string
+    const queryString = Object.keys(additionalParams).map(key => key + '=' + additionalParams[key]).join('&');
+    return this.client.post('/v1/shopping/flight-offers/pricing?' + queryString, JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/shopping/flight_offers/upselling.js
+++ b/src/amadeus/namespaces/shopping/flight_offers/upselling.js
@@ -27,7 +27,7 @@ class Upselling {
    * ```
    */
   post(params = {}) {
-    return this.client.post('/v1/shopping/flight-offers/upselling', params);
+    return this.client.post('/v1/shopping/flight-offers/upselling', JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/shopping/flight_offers_search.js
+++ b/src/amadeus/namespaces/shopping/flight_offers_search.js
@@ -52,7 +52,7 @@ class FlightOffersSearch {
    * To do a customized search with given options.
    *
    * ```js
-   * amadeus.shopping.flightOffersSearch.post (JSON.stringify({
+   * amadeus.shopping.flightOffersSearch.post ({
         "currencyCode": "USD",
         "originDestinations": [
           {
@@ -114,11 +114,11 @@ class FlightOffersSearch {
             }
           }
         }
-      }))
+      })
     * ```
     */
   post(params = {}) {
-    return this.client.post('/v2/shopping/flight-offers', params);
+    return this.client.post('/v2/shopping/flight-offers',JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/shopping/seatmaps.js
+++ b/src/amadeus/namespaces/shopping/seatmaps.js
@@ -51,15 +51,15 @@ class Seatmaps {
    *    departureDate: '2020-08-01'
    * }).then(function(response){
    *    return amadeus.shopping.flightOffers.seatmaps.post(
-   *        JSON.stringify({
+   *        {
    *            'data': response.data
-   *        })
+   *        }
    *    );
    * });
    * ```
   */
   post(params = {}) {
-    return this.client.post('/v1/shopping/seatmaps', params);
+    return this.client.post('/v1/shopping/seatmaps', JSON.stringify(params));
   }
 
 }

--- a/src/amadeus/namespaces/shopping/transfer_offers.js
+++ b/src/amadeus/namespaces/shopping/transfer_offers.js
@@ -31,7 +31,7 @@ class TransferOffers {
    * ```
   */
   post(params = {}) {
-    return this.client.post('/v1/shopping/transfer-offers', params);
+    return this.client.post('/v1/shopping/transfer-offers', JSON.stringify(params));
   }
 }
 

--- a/src/amadeus/namespaces/travel/trip_parser.js
+++ b/src/amadeus/namespaces/travel/trip_parser.js
@@ -29,7 +29,7 @@ class TripParser {
      * ```
      */
   post(params = {}) {
-    return this.client.post('/v3/travel/trip-parser', params);
+    return this.client.post('/v3/travel/trip-parser', JSON.stringify(params));
   }
   /**
   * Helper method to convert file contents in UTF-8 encoded string


### PR DESCRIPTION
There are 2 features updated:
- support additional parameter `include=xxx` for Flight offer price API.
- support `JSON.stringify` for all post menthods, so that user doesn't need to specify JSON.stringify 

Once it is approved and merged, Next steps are: 
- to release new version 
- to update README for code examples 
- to update code-example repo 