### PR TITLE
Simplify node version retrieval

### DIFF
--- a/src/amadeus/client.js
+++ b/src/amadeus/client.js
@@ -174,7 +174,7 @@ class Client {
       params: params,
       bearerToken: bearerToken,
       clientVersion: this.version,
-      languageVersion: process.version,
+      languageVersion: process.versions.node,
       appId: this.customAppId,
       appVersion: this.customAppVersion,
       port: this.port,

--- a/src/amadeus/client/request.js
+++ b/src/amadeus/client/request.js
@@ -33,7 +33,7 @@ class Request {
     this.queryPath       = this.fullQueryPath();
     this.bearerToken     = options.bearerToken;
     this.clientVersion   = options.clientVersion;
-    this.languageVersion = options.languageVersion.replace('v', '');
+    this.languageVersion = options.languageVersion
     this.appId           = options.appId;
     this.appVersion      = options.appVersion;
     this.headers         = {

--- a/src/amadeus/client/request.js
+++ b/src/amadeus/client/request.js
@@ -33,7 +33,7 @@ class Request {
     this.queryPath       = this.fullQueryPath();
     this.bearerToken     = options.bearerToken;
     this.clientVersion   = options.clientVersion;
-    this.languageVersion = options.languageVersion
+    this.languageVersion = options.languageVersion;
     this.appId           = options.appId;
     this.appVersion      = options.appVersion;
     this.headers         = {


### PR DESCRIPTION
## Simplify Node Version Retrieval

### Changes Made
- Updated the method for fetching Node.js version in the codebase.
- Replaced the usage of `process.version` and manual removal of 'v' with `process.versions.node`.

### Impact
This change improves code readability and eliminates the need for additional string manipulation, making the codebase cleaner and more straightforward.

### Motivation
The current implementation involves fetching the Node.js version using `process.version` and then manually removing the 'v' character. This pull request simplifies the process by directly utilizing `process.versions.node` to obtain the Node.js version without the 'v' character.

### Test
No functional changes have been made; this is a refactoring to enhance code simplicity.

### Checklist
- [x] Updated Node.js version retrieval to use `process.versions.node`.
- [x] Ensured backward compatibility and no functional changes.
- [x] Tested the code to ensure it functions as expected.

### Additional Information
- No breaking changes expected.