### PR TITLE
Correctly encoding arrays for GET requests

### DIFF
--- a/spec/amadeus/client/request.test.js
+++ b/spec/amadeus/client/request.test.js
@@ -102,6 +102,15 @@ describe('Request', () => {
         request.params = null;
         expect(request.fullQueryPath()).toBe('/foo/bar?');
       });
+
+      it('should serialize array params as comma-separated values', () => {
+        request.verb = 'GET';
+        request.params = {
+          amenities: ['bar', 'baz'],
+          ratings: [4, 5],
+        };
+        expect(request.fullQueryPath()).toBe('/foo/bar?amenities=bar%2Cbaz&ratings=4%2C5');
+      });
     });
 
     describe('.body', () => {

--- a/src/amadeus/client/request.js
+++ b/src/amadeus/client/request.js
@@ -115,7 +115,7 @@ class Request {
    */
   fullQueryPath() {
     if (this.verb === 'POST') { return this.path; }
-    else { return `${this.path}?${qs.stringify(this.params)}`; }
+    else { return `${this.path}?${qs.stringify(this.params, { arrayFormat: 'comma' })}`; }
   }
 
   /**


### PR DESCRIPTION
## Description
Fixes #220

Users were required to convert arrays of strings to comma-separated lists manually, for them to work as parameters in GET requests.
With this fix, the qs library properly encodes arrays as comma-separated lists of values.

## Changes for this pull request
* Added `arrayFormat: 'comma'` to the options passed to `qs.stringify`
* Added the relevant test case for this behavior
